### PR TITLE
Par défaut vmg lance une nouvelle instance à chaque fois

### DIFF
--- a/src/scripts/Aciah-Menu
+++ b/src/scripts/Aciah-Menu
@@ -80,7 +80,7 @@ cmd = google-chrome-stable https://www.textfromtospeech.com/fr/voice-to-text/
 icon = 
 
 item = Petite loupe non cliquable - ou CTRL + Espace
-cmd = vmg
+cmd = bash -c 'pkill vmg ; vmg'
 icon = 
 
 SEPARATOR


### PR DESCRIPTION
Bonjour,

Le changement de commande en `bash -c 'pkill vmg ; vmg'` au lieu de `vmg`, ça permet de fermer l'instance si elle existe avant d'en relancer une nouvelle.

Il faudra également changement les touches raccourcis, il me semble, car je ne crois que ma PR ne concerne que le menu Aciah Linux

Bonne journée